### PR TITLE
Alter TWA snapshot parameters

### DIFF
--- a/contracts/RewardsHandler.vy
+++ b/contracts/RewardsHandler.vy
@@ -156,7 +156,7 @@ def __init__(
 
     twa.__init__(
         WEEK,  # twa_window = 1 week
-        600,  #  min_snapshot_dt_seconds = 600 seconds
+        3_600,  #  min_snapshot_dt_seconds = 1 hour (3600 sec)
     )
 
     self._set_minimum_weight(minimum_weight)

--- a/contracts/RewardsHandler.vy
+++ b/contracts/RewardsHandler.vy
@@ -209,7 +209,7 @@ def _take_snapshot():
 
 
 @external
-def process_rewards(take_snapshot: bool = True):
+def process_rewards(take_snapshot: bool = False):
     """
     @notice Permissionless function that let anyone distribute rewards (if any) to
     the crvUSD vault.

--- a/contracts/TWA.vy
+++ b/contracts/TWA.vy
@@ -51,10 +51,10 @@ MAX_SNAPSHOTS: constant(uint256) = 10**18  # 31.7 billion years if snapshot ever
 ################################################################
 
 
-snapshots: public(DynArray[Snapshot, MAX_SNAPSHOTS])
 min_snapshot_dt_seconds: public(uint256)  # Minimum time between snapshots in seconds
 twa_window: public(uint256)  # Time window in seconds for TWA calculation
 last_snapshot_timestamp: public(uint256)  # Timestamp of the last snapshot
+snapshots: public(DynArray[Snapshot, MAX_SNAPSHOTS])
 
 
 struct Snapshot:

--- a/tests/unitary/rewards_handler/test_process_rewards.py
+++ b/tests/unitary/rewards_handler/test_process_rewards.py
@@ -33,7 +33,7 @@ def test_snapshots_taking(rewards_handler, rate_manager, crvusd):
     rewards_handler.set_distribution_time(1234, sender=rate_manager)  # to enable process_rewards
     assert rewards_handler.get_len_snapshots() == 0
     boa.deal(crvusd, rewards_handler, 1)
-    rewards_handler.process_rewards()
+    rewards_handler.process_rewards(True)  # True to take snapshot
     assert crvusd.balanceOf(rewards_handler) == 0  # crvusd gone
     assert rewards_handler.get_len_snapshots() == 1  # first snapshot taken
 
@@ -44,6 +44,6 @@ def test_snapshots_taking(rewards_handler, rate_manager, crvusd):
 
     boa.env.time_travel(seconds=rewards_handler.min_snapshot_dt_seconds())
     boa.deal(crvusd, rewards_handler, 1)
-    rewards_handler.process_rewards()
+    rewards_handler.process_rewards(False)  # False to not take snapshot
     assert crvusd.balanceOf(rewards_handler) == 0  # crvusd gone (they always go)
-    assert rewards_handler.get_len_snapshots() == 2  # changed since dt has passed
+    assert rewards_handler.get_len_snapshots() == 1  # not changed since dt has passed but False

--- a/tests/unitary/rewards_handler/test_rh_constructor.py
+++ b/tests/unitary/rewards_handler/test_rh_constructor.py
@@ -33,4 +33,4 @@ def test_default_behavior(
     # eoa would be the deployer from which we revoke the role
     assert not rewards_handler.hasRole(rewards_handler.DEFAULT_ADMIN_ROLE(), boa.env.eoa)
     assert rewards_handler.eval("twa.twa_window") == 86_400 * 7
-    assert rewards_handler.eval("twa.min_snapshot_dt_seconds") == 600  # 10 minutes
+    assert rewards_handler.eval("twa.min_snapshot_dt_seconds") == 3600  # 1 hr


### PR DESCRIPTION
### Summary of Changes

1. **Increased Snapshot Interval**: 
   - The snapshot interval is now set to 1 hour (3_600 s), which reduces gas consumption.
   - Each snapshot costs ~5_500 gas in `.compute_twa()`. Over 7 days, this results in a maximum gas usage of 86_400 * 7 / 3_600 * 5_500 = 924_000 (compared to the previous, more frequent intervals).

2. **Reordered Variables in `twa` Module**: 
   - Variables were reordered to produce cleaner and more readable memory addresses during debugging, making the module easier to work with.

3. **Removed Default Snapshots in `process_rewards()`**: 
   - Snapshots are no longer taken by default when calling `process_rewards()`, avoiding unnecessary gas costs (170_000 gas for `lens.circulating_supply()` when iterating through peg keepers and controllers).
   - To include snapshots when using automated keepers, one should call `process_rewards(True)`.